### PR TITLE
Hotfix/210526ch

### DIFF
--- a/src/main/java/com/ncncn/task/AutoPriceUpdateTask.java
+++ b/src/main/java/com/ncncn/task/AutoPriceUpdateTask.java
@@ -60,6 +60,12 @@ public class AutoPriceUpdateTask {
         Date today = new Date();
         long diffInMillies = expDt.getTime() - today.getTime();
         int dateDiff = (int)Math.ceil(diffInMillies/(1000 * 3600 * 24.0));
+
+        // 유효기간까지 남은 날짜가 60보다 크면 추가할인율 없음
+        if(dateDiff > 60) {
+            return inDcRate;
+        }
+
         log.info("dateDiff: " + dateDiff);
 
         // 할인율 구간 구분

--- a/src/main/java/com/ncncn/task/AutoPriceUpdateTask.java
+++ b/src/main/java/com/ncncn/task/AutoPriceUpdateTask.java
@@ -23,6 +23,7 @@ public class AutoPriceUpdateTask {
     public void updatePrices() {
 
         try {
+            // 자동가격 설정된 기프티콘 중 자동할인율 변경구간(유효기간까지 59, 44, 29, 14일)에 해당되는 기프티콘 가져오기
             List<AutoPriceVO> list = gifticonMapper.getAutoPricedGifticon();
             log.info(list);
             for (AutoPriceVO gifticon : list) {
@@ -60,11 +61,6 @@ public class AutoPriceUpdateTask {
         Date today = new Date();
         long diffInMillies = expDt.getTime() - today.getTime();
         int dateDiff = (int)Math.ceil(diffInMillies/(1000 * 3600 * 24.0));
-
-        // 유효기간까지 남은 날짜가 60보다 크면 추가할인율 없음
-        if(dateDiff > 60) {
-            return inDcRate;
-        }
 
         log.info("dateDiff: " + dateDiff);
 

--- a/src/main/resources/com/ncncn/mapper/GifticonMapper.xml
+++ b/src/main/resources/com/ncncn/mapper/GifticonMapper.xml
@@ -445,6 +445,7 @@
                  left outer join product p on g.prod_code = p.code
         where g.is_auto_prc = 1
           and (g.gft_stus_code = '001' or g.gft_stus_code = '002')
+          and DATEDIFF(g.expir_dt, now()) IN (59, 44, 29, 14)
     </select>
 
     <select id="getOnSaleGifticon" resultType="com.ncncn.domain.GifticonVO">
@@ -467,7 +468,7 @@
         set dc_prc  = #{dcPrc},
             dc_rate = #{dcRate},
             up_date = now(),
-            up_user = current_user()
+            up_user = 'AutoPriceTask'
         where id = #{id}
     </update>
 


### PR DESCRIPTION
- AutoPriceUpdateTask 수정

자동가격 설정된 기프티콘 중 자동할인율 변경구간(유효기간까지 59, 44, 29, 14일)에 해당되는 기프티콘들만 불러와서 가격을 변경합니다
Task로 가격 변경시 gifticon Table의 up_user 컬럼에 AutoPriceTask를 입력합니다